### PR TITLE
Allow packages to install multiple files

### DIFF
--- a/resources/packages/loader/bin/loader.fnl
+++ b/resources/packages/loader/bin/loader.fnl
@@ -1,0 +1,180 @@
+(local internet (require "internet"))
+(local filesystem (require "filesystem"))
+(local serialization (require "serialization"))
+(local loader-package-id "loader")
+
+(fn load-vega-config
+  []
+  (local (file err) (filesystem.open "/home/vega.host"))
+  (if (= nil err)
+      (let [host (file:read 1024)]
+        (file:close)
+        host)
+      ""))
+
+(var vega "http://localhost:8080")
+(local config-host (load-vega-config))
+(if (> (string.len config-host) 0)
+    (set vega config-host))
+(fn package-url-with-query-string
+  [repository id query-string]
+  (let [url (.. repository id)]
+    (if (> (string.len query-string) 0)
+        (.. url "?" query-string)
+        url)))
+(local package-repository (.. vega "/packages/"))
+(fn package-url [repository id]
+  (package-url-with-query-string repository id ""))
+(fn ensure-directory!
+  [dir]
+  (filesystem.makeDirectory dir))
+(fn http-get [url]
+  (let [handle (internet.request url)]
+    (var done false)
+    (var response "")
+    (while (not done)
+      (local buffer (handle.read))
+      (if (= nil buffer)
+          (set done true)
+          (set response (.. response buffer))))
+    response))
+(fn spit
+  [path content]
+  (local (file err) (io.open path "w"))
+  (if file
+      (do
+        (file:write content)
+        (file:close)
+        nil)
+      err))
+(fn slurp
+  [path]
+  (local (file err) (io.open path))
+  (if file
+      (do
+        (var buffer "")
+        (var read (file:read))
+        (while (not (= read nil))
+          (set buffer (.. buffer read))
+          (set read (file:read)))
+        (file:close)
+        (values buffer nil))
+      (values nil err)))
+(fn http-download-to
+  [url path]
+  (filesystem.makeDirectory (filesystem.path path))
+  (let [result (spit path (http-get url))]
+    (when (~= nil result)
+      (print err))))
+(fn get-manifest
+  [pkg]
+  (let [manifest (http-get (package-url-with-query-string package-repository pkg "manifest"))]
+    (serialization.unserialize manifest)))
+(fn local-manifest-path
+  [pkg]
+  (.. "/home/.loader/manifests/" pkg ".manifest"))
+(fn get-local-manifest
+  [pkg]
+  (let [manifest-path (local-manifest-path pkg)
+        (manifest err) (slurp manifest-path)]
+    (when (= err nil)
+        (serialization.unserialize manifest))))
+(fn ensure-loader-dir!
+  []
+  (ensure-directory! "/home/.loader"))
+(fn path-table
+  [list]
+  (var index [])
+  (each [_ k (pairs list)]
+    (tset index k.installPath k))
+  index)
+(fn keys
+  [t]
+  (var k-list [])
+  (each [k (pairs t)]
+    (table.insert k-list k))
+  k-list)
+(fn diff-table
+  [a b]
+  (let [a-keys (keys a)]
+    (var special [])
+    (each [_ ak (pairs a-keys)]
+      (when (= nil (. b ak))
+          (table.insert special (. a ak))))
+    special))
+(fn get-patch-list
+  [desired current]
+  (if (= nil desired)
+      (values {} current)
+      (if (= nil current)
+          (values desired {})
+          (do
+            (var to-patch [])
+            (let [desired-paths (path-table desired)
+                  current-paths (path-table current)]
+              (each [i f (pairs desired-paths)]
+                (let [current-state (. current-paths i)
+                      current-checksum (and (~= nil current-state) current-state.checksum)]
+                  (when (~= current-checksum f.checksum)
+                    (table.insert to-patch f)))
+                )
+              (values to-patch (diff-table current-paths desired-paths)))))))
+(fn patch-files!
+  [entries]
+  (each [_ entry (ipairs entries)]
+    (let [url (.. vega "/" entry.url)
+          install-path entry.installPath]
+      (print (.. url " => " install-path))
+      (ensure-directory! (filesystem.path (filesystem.concat "/home" install-path)))
+      (http-download-to url install-path))))
+(fn delete-files!
+  [entries]
+  (each [_ entry (ipairs entries)]
+    (print (.. "delete stalled file: " entry.installPath))
+    (os.remove (filesystem.concat "/home" entry.installPath))))
+(fn update-local-manifest!
+  [pkg manifest]
+  (local manifest-path (local-manifest-path pkg))
+  (ensure-directory! (filesystem.path manifest-path))
+  (let [result (spit manifest-path (serialization.serialize manifest))]
+    (when result
+      (print "failed to update manifest")
+      (print result))))
+
+(fn ensure-package
+  [pkg]
+  (print "checking manifest ....")
+  (local local-manifest (get-local-manifest pkg))
+  (print (.. "local checksum: " (if local-manifest
+                                    local-manifest.checksum
+                                    "missing")))
+  (local remote-manifest (get-manifest pkg))
+  (if (= nil remote-manifest)
+      (print (.. "package " pkg " doesn't exist on the vega"))
+      (do
+        (print (.. "remote checksum: " remote-manifest.checksum))
+        (when (or (= nil local-manifest) (not (= local-manifest.checksum remote-manifest.checksum)))
+          (print (.. "package " pkg " needs update"))
+          (let [(to-patch to-delete) (get-patch-list remote-manifest.files (and local-manifest local-manifest.files))]
+            (patch-files! to-patch)
+            (delete-files! to-delete))
+          (update-local-manifest! pkg remote-manifest)))))
+(ensure-loader-dir!)
+(ensure-package "loader")
+(fn delete-manifest!
+  [pkg]
+  (os.remove (local-manifest-path pkg)))
+(fn uninstall-package
+  [pkg]
+  (local manifest (get-local-manifest pkg))
+  (if (= nil manifest)
+      (print (.. "package " pkg " is not installed"))
+      (do
+        (delete-files! manifest.files)
+        (delete-manifest! pkg)
+        (print (.. "package " pkg " uninstalled")))))
+(local args [...])
+(match (. args 1)
+  "ensure" (ensure-package (. args 2))
+  "uninstall" (uninstall-package (. args 2))
+  (print "unknown command"))

--- a/src/vega/core.clj
+++ b/src/vega/core.clj
@@ -21,7 +21,7 @@
 
 (defroutes all-routes
   (GET "/" [] hello)
-  (GET "/packages/:id" [] (packages/package-repository "resources/packages/"))
+  (GET "/packages/*" [] (packages/service "resources/packages/"))
   (GET "/websocket" [] (partial debugging/handler debugging-pub))
   (POST "/log" [] (partial debugging/log-handler debugging-message-ch))
   (cr/not-found {:status 404 :body "vega can't understand this :<"}))

--- a/src/vega/fennel.clj
+++ b/src/vega/fennel.clj
@@ -6,5 +6,5 @@
   "transpile fennel source file to lua"
   [path]
   (let [result (shell/sh "fennel" "--compile" path)]
-    (when-not (empty? (:err result)) (throw (Exception. "compile error")))
+    (when-not (empty? (:err result)) (throw (ex-info "compile error" result)))
     (:out result)))

--- a/src/vega/file.clj
+++ b/src/vega/file.clj
@@ -1,5 +1,6 @@
 (ns vega.file
-  (:require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as cs]))
 
 (defn file-extension
   "return file extension without period"
@@ -7,3 +8,8 @@
   (when path (second (re-find #"\.([^\\]+)$" path))))
 
 (defn exists? [path] (.exists (io/file path)))
+
+(defn replace-extension
+  "replace file extension"
+  [path ext]
+  (cs/replace path #"(.+)\.(\S+)$" (str "$1." ext)))

--- a/src/vega/packages.clj
+++ b/src/vega/packages.clj
@@ -1,7 +1,10 @@
 (ns vega.packages
   (:require [taoensso.timbre :as l]
             [vega.fennel :as fennel]
-            [vega.file :as f])
+            [vega.file :as f]
+            [vega.serialization :as vs]
+            [clojure.java.io :as io]
+            [clojure.string :as cs])
   (:import [java.security MessageDigest]))
 
 (defn md5 [^String s]
@@ -12,9 +15,9 @@
 (defn id-handler
   "wrapper for handlers that only want the id of the requesting package"
   [handler]
-  (fn [req] (handler (-> req :params :id))))
+  (fn [req] (handler (-> req :params :*))))
 
-(defn package-header [content] (str "--[[" (md5 content) "]]--\n" content))
+(defn package-header [content] (str "--[[" (md5 content) "]]--"))
 
 (defn find-paths [paths]
   (loop [to-try paths]
@@ -24,22 +27,69 @@
         (if exists path (recur (rest to-try)))))))
 
 (defn get-source [root id]
-  (let [path (find-paths (map #(str root id %) [".lua" ".fnl"]))
+  (let [path (str root id)
         ext (f/file-extension path)]
     (when path
-      (if (= "fnl" ext) (fennel/transpile-file path) (slurp path)))))
+      (let [source (slurp path)]
+        (if (= "fnl" ext)
+          [source (fennel/transpile-file path)]
+          [source source])))))
 
 (defn package-info
   "serve package info (e.g) md5 hash, last modified. print it out in body beause it's not convenient to read headers from openComputers"
-  [root id] (let [s (get-source root id)] {:status (if s 200 404) :body (when s (md5 s))}))
+  [root id] (let [[s] (get-source root id)] {:status (if s 200 404) :body (when s (md5 s))}))
 
 (defn package-content-handler
   [root id]
-  (let [source (get-source root id)]
-    {:status (if source 200 404)
-     :body (when source (package-header source))}))
+  (let [[source compiled] (get-source root id)]
+    {:status (if compiled 200 404)
+     :body (when compiled (str (package-header source) "\n" compiled))}))
 
-(defn package-repository [root]
-  (fn [req] (cond
-              (= (-> req :query-string) "md5") (id-handler (partial package-info root))
-              (constantly true) (id-handler (partial package-content-handler root)))))
+(defn- trim-prefix
+  [prefix s]
+  (cs/replace
+   s
+   (re-pattern (str "^\\Q" prefix "\\E"))
+   ""))
+
+(defn generate-manifest
+  [package trim-path]
+  (comp
+   (filter #(.isFile %))
+   (map #(.getPath %))
+   (map (fn [path]
+          (let [relative-path (trim-prefix trim-path path)]
+            (list
+             (md5 (slurp path))
+             (str "packages/" package "/" relative-path)
+             (if (= "fnl" (f/file-extension relative-path))
+               (f/replace-extension relative-path "lua")
+               relative-path)))))
+   (map (fn [[checksum url install-path]]
+          {"checksum" checksum
+           "url" url
+           "installPath" install-path}))))
+
+(defn- manifest
+  [root id]
+  (let [dir-path (str root id "/")
+        dir (io/file dir-path)]
+    (if (.exists dir)
+      {:status 200
+       :body
+       (let [results (transduce
+                      (generate-manifest id dir-path)
+                      conj
+                      (file-seq dir))
+             checksum (md5 (vs/serialize results))]
+         (vs/serialize {"checksum" checksum
+                        "files" results}))
+       :headers
+       {"content-type" "text/plain"}}
+      {:status 404 :body (str "package " id " doesn't exist")})))
+
+(defn service [root]
+  (fn [req] (case (:query-string req)
+              "md5" (id-handler (partial package-info root))
+              "manifest" (id-handler (partial manifest root))
+              (id-handler (partial package-content-handler root)))))

--- a/src/vega/serialization.clj
+++ b/src/vega/serialization.clj
@@ -1,0 +1,28 @@
+(ns vega.serialization
+  (:require [clojure.string :as cs]))
+
+(declare serialize-fn)
+(declare serialize)
+
+(def separator ", ")
+
+(defn- serialize-list
+  [data]
+  #(str "{" (cs/join separator (map serialize data)) "}"))
+
+(defn- serialize-map
+  [m]
+  #(str "{" (cs/join separator (map (fn [[k v]] (str k " = " (serialize v))) (seq m))) "}"))
+
+(defn- serialize-fn
+  [data]
+  (cond
+    (map? data) (serialize-map data)
+    (list? data) (serialize-list data)
+    (vector? data) (serialize-list data)
+    (string? data) (str "\"" data "\"")
+    (constantly true) data))
+
+(defn serialize
+  [data]
+  (trampoline serialize-fn data))

--- a/test/vega/serialization_test.clj
+++ b/test/vega/serialization_test.clj
@@ -4,4 +4,4 @@
 
 (deftest test-serialize
   (testing "serialize an array"
-    (is (= "{1,2,3,4}" (serialize '(1 2 3 4))))))
+    (is (= "{1, 2, 3, 4}" (serialize '(1 2 3 4))))))

--- a/test/vega/serialization_test.clj
+++ b/test/vega/serialization_test.clj
@@ -1,0 +1,7 @@
+(ns vega.serialization-test
+  (:require [clojure.test :refer :all]
+            [vega.serialization :refer :all]))
+
+(deftest test-serialize
+  (testing "serialize an array"
+    (is (= "{1,2,3,4}" (serialize '(1 2 3 4))))))


### PR DESCRIPTION
Close #15 
1. implement manifest package API (/package/<package-name>?manifest)
2. rewrite the loader (in fennel) to allow installing multiple files